### PR TITLE
added jitpack version of google-api-translate-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,13 +163,17 @@
 	<artifactId>google-api-translate-java</artifactId>
 	<version>0.92</version>
 </dependency-->
-<dependency>
+<!--dependency>
     <groupId>com.googlecode</groupId>
     <artifactId>google-api-translate-java</artifactId>
     <version>0.97</version>
-    <!--scope>system</scope>
-    <systemPath>${basedir}/lib/google-api-translate-java-0.97.jar</systemPath-->
-</dependency>
+</dependency-->
+	<dependency>
+	    <groupId>com.github.richmidwinter</groupId>
+	    <artifactId>google-api-translate-java</artifactId>
+	    <version>421c3f637b</version> <!-- should correspond to version 0.97-->
+	</dependency>
+
 <!--dependency>
 	<groupId>eu.sealsproject.omt</groupId>
 	<artifactId>omt-client</artifactId>
@@ -205,6 +209,13 @@
 
 
 </dependencies>
+
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
 
 <!-- Important to add stopwords and lexicon files-->
   <build>


### PR DESCRIPTION
Hi Ernesto,

I would like to use some logmap parts in MELT.
Due to the fact that it is not yet in Maven Central I tried it with [JitPack](https://jitpack.io).
Unfortunately it didn't worked out because of the google-api dependency (see [here](https://jitpack.io/#ernestojimenezruiz/logmap-matcher) and the corresponding [log](https://jitpack.io/com/github/ernestojimenezruiz/logmap-matcher/logmap-matcher-july-2021/build.log)).
I searched for the dependency (which is not in central again) and found it [in github as well](https://github.com/richmidwinter/google-api-translate-java).

Thus I changed you pom.xml file to include the jitpack repository and the (hopefully correct) version of the library (it should be the last 0.97-SNAPSHOT version).
Can you check if the translation feature of logmap is still working with it?

If yes, you can merge it and all maven users will be able to include logmap in their projects via

```
<dependency>
	<groupId>com.github.ernestojimenezruiz</groupId>
	<artifactId>logmap-matcher</artifactId>
	<version>Tag</version>
</dependency>
```
together with

```
<repositories>
  <repository>
      <id>jitpack.io</id>
      <url>https://jitpack.io</url>
  </repository>
</repositories>
```

Best regards
Sven