### PR TITLE
fix: bypass the need for isAnonymous() check in SyntacticLocalityChecker.java

### DIFF
--- a/src/main/java/uk/ac/manchester/syntactic_locality/SyntacticLocalityChecker.java
+++ b/src/main/java/uk/ac/manchester/syntactic_locality/SyntacticLocalityChecker.java
@@ -1110,7 +1110,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    	
 	    	//Only for dual
 			if (dualRoles && isNegativeOWLClassExpression(desc.getFiller()) 
-					&& !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+					&& !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 				isNegativeDescription=true;
 			
 			//Bottom is always false
@@ -1153,7 +1153,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    	if (isNegativeOWLClassExpression(desc.getFiller()))
 	    		isNegativeDescription=true;
 	    	//Only bottom
-	    	else if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    	else if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 	    		isNegativeDescription=true;
 	    	else
 	    		isNegativeDescription=false;
@@ -1183,7 +1183,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    public void visit(OWLObjectHasSelf desc) {
 	    	//Only bottom
 	    	//For dual: if prop are not in signature --> Top
-	    	if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    	if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 	    		isNegativeDescription = true;
 	    	else
 	    		isNegativeDescription = false;
@@ -1201,7 +1201,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    	//Changed by Ana
 	    	//if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()) &&
 	    	//		!foreignSignature.contains(desc.getValue()))
-	    	if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    	if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 	    		isNegativeDescription = true;
 	    	else
 	    		isNegativeDescription = false;
@@ -1234,7 +1234,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 		    	if (isNegativeOWLClassExpression(desc.getFiller()))
 		    		isNegativeDescription=true;
 		    	//Only bottom
-		    	else if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+		    	else if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 		    		isNegativeDescription=true;
 		    	else
 		    		isNegativeDescription=false;
@@ -1242,7 +1242,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    	
 	    	//Non qualified cardinalities
 	    	else {
-	    		if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    		if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 		    		isNegativeDescription=true;
 		    	else
 		    		isNegativeDescription=false;
@@ -1277,7 +1277,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    	if (desc.isQualified()) {
 	    		//Only for dual
 				if (dualRoles && isNegativeOWLClassExpression(desc.getFiller()) 
-						&& !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+						&& !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 					isNegativeDescription=true;
 				
 				//Bottom is always false
@@ -1288,7 +1288,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    	}
 	    	else {
 	    		
-	    		if (dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    		if (dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 					isNegativeDescription=true;
 				
 				//Bottom is always false
@@ -1326,14 +1326,14 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    		
 	    		//Both duaRoles and nonDual 
 				if (isNegativeOWLClassExpression(desc.getFiller()) && 
-						!foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+						!foreignSignature.contains(desc.getProperty().getNamedProperty()))
 					isNegativeDescription=true;
 				
 				else
 					isNegativeDescription=false;
 	    	}
 	    	else {
-	    		if (!foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    		if (!foreignSignature.contains(desc.getProperty().getNamedProperty()))
 					isNegativeDescription=true;
 				
 				else
@@ -1483,19 +1483,22 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 
 	    
 
-
-	    public void visit(OWLObjectAllValuesFrom desc) {
-	    	
-	    	//All
+		/**
+		 * JD. else if branch now chains `.getNamedProperty()` to `desc.getProperty()`.
+		 * This is performed in place of `.asOWLObjectProperty()`, which requires
+		 * an explicit `.isAnonymous()` check, since it the return value can be either `inv(p)` or `p`.
+		 * See:
+		 * https://owlcs.github.io/owlapi/apidocs_4/org/semanticweb/owlapi/model/OWLObjectPropertyExpression.html#asOWLObjectProperty--
+		 * https://owlcs.github.io/owlapi/apidocs_5/org/semanticweb/owlapi/model/OWLObjectProperty.html#getNamedProperty--
+		 */
+		public void visit(OWLObjectAllValuesFrom desc) {
 			if (isPositiveOWLClassExpression(desc.getFiller()))
 				isPositiveDescription = true;
-			//Only for bottom roles
-			else if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+			else if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 				isPositiveDescription = true;
 			else
 				isPositiveDescription = false;
-	    	
-	    }
+		}
 	    
 	    
 	    public void visit(OWLDataAllValuesFrom desc) {
@@ -1514,7 +1517,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    
 	    public void visit(OWLObjectSomeValuesFrom desc) {
 	    	
-	    	if (dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty())
+	    	if (dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty())
 	    			&& isPositiveOWLClassExpression(desc.getFiller()))
 	    		isPositiveDescription = true;
 	    	else
@@ -1545,7 +1548,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    public void visit(OWLObjectHasValue desc) {
 	    	//Only dual
 	    	//For dual: if prop are not in signature --> Top
-	    	if (dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()) &&
+	    	if (dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()) &&
 	    			!foreignSignature.contains(desc.getValue()))
 	    		isPositiveDescription = true;
 	    	else
@@ -1574,14 +1577,14 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    public void visit(OWLObjectMinCardinality desc) {
 	    	
 	    	if (desc.isQualified()){
-		    	if (dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()) 
+		    	if (dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()) 
 		    		&& isPositiveOWLClassExpression(desc.getFiller()))
 		    		isPositiveDescription = true;
 		    	else
 		    		isPositiveDescription = false;
 	    	}
 	    	else {
-	    		if (dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    		if (dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 			    	isPositiveDescription = true;
 			    else
 			    	isPositiveDescription = false;
@@ -1606,7 +1609,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 			if (isPositiveOWLClassExpression(desc.getFiller()))
 				isPositiveDescription = true;
 			//Only for bottom roles
-			else if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+			else if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 				isPositiveDescription = true;
 			else
 				isPositiveDescription = false;
@@ -1647,7 +1650,7 @@ public class SyntacticLocalityChecker implements OWLAxiomVisitor {
 	    	    				
 	    	}
 	    	else {
-	    		if (dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
+	    		if (dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty()))
 			    	isPositiveDescription = true;
 			    else
 			    	isPositiveDescription = false;


### PR DESCRIPTION
# PR to fix issue(s) in SyntacticLocalityChecker.java:

## TLDR:

In [SyntacticLocalityCheck.java](https://github.com/ernestojimenezruiz/logmap-matcher/blob/master/src/main/java/uk/ac/manchester/syntactic_locality/SyntacticLocalityChecker.java) there are many calls to `desc.getProperty().asOWLObjectProperty()` that do not first check whether `desc.getProperty()` returns a named or an anonymous expression. The OWL API documentation states that when using `.asOWLObjectProperty()` a check to `.isAnonymous()` should first be made. We bypass the need for this by instead calling replacing all offending instances with `.getNamedProperty()`, which "Returns P if this expression is either P or inv(P)."

## Description: Issue

SyntacticLocalityChecker.java contains 37 string matches agaisnt "*.contains(desc.getProperty().asOWLObjectProperty*". You can check the count with:
```sh
grep -cnE 'contains\(.*\.asOWL[A-Za-z]*ObjectProperty\(\)\)' /home/jon/logmap_fixes/logmap-matcher/src/main/java/uk/ac/manchester/syntactic_locality/SyntacticLocalityChecker.java
```

Use:
```sh
grep -nE 'contains\(.*\.asOWL[A-Za-z]*ObjectProperty\(\)\)' /home/jon/logmap_fixes/logmap-matcher/src/main/java/uk/ac/manchester/syntactic_locality/SyntacticLocalityChecker.java
```

to see the actual matches and line numbers. Note: 

> "If the property is a named object property then this method will obtain the property as such. The general pattern of use is that the isAnonymous method should first be used to determine if the property is named (i.e. not an object property expression such as inv(p)). If the property is named then this method may be used to obtain the property as a named property without casting. Throws: OWLRuntimeException - if the property is not a named property." <--

Source: from `.asOWLObjectProperty()` doc-string [[1]](https://owlcs.github.io/owlapi/apidocs_4/org/semanticweb/owlapi/model/OWLObjectPropertyExpression.html#asOWLObjectProperty--).

The method:

```java
public void visit(OWLObjectAllValuesFrom desc) {
	//All
	if (isPositiveOWLClassExpression(desc.getFiller()))
		isPositiveDescription = true;
	//Only for bottom roles
	else if (!dualRoles && !foreignSignature.contains(desc.getProperty().asOWLObjectProperty()))
		isPositiveDescription = true;
	else
		isPositiveDescription = false;
}
```

will not explicitly check `desc.getProperty().isAnonymous()` before calling `.asOWLObjectProperty()` (in rare cases, this will raise an OWLRuntimeException).

An example stacktrace is provided below when running LogMap on [DISO compact ontologies](https://github.com/city-artificial-intelligence/diso):

```
java -Xmx8g -Xms500M -DentityExpansionLimit=10000000 --add-opens=java.base/java.lang=ALL-UNNAMED -jar /home/jon/repos/DISO-mappings/matchers/logmap/logmap-matcher-4.0.jar MATCHER file:///home/jon/repos/DISO-mappings/data/diso-compact/smart-environments/smart-buildings/Brick%2Bimports.ttl file:///home/jon/repos/DISO-mappings/data/diso-compact/smart-environments/smart-homes/SmartEnvMerged.ttl /tmp/logmap-99dsrg2i-Brick+imports__SmartEnvMerged/ false
	org.semanticweb.owlapi.model.OWLRuntimeException: Property is not a named property. Check using the isAnonymous method before calling this method!
	at uk.ac.manchester.cs.owl.owlapi.OWLObjectInverseOfImpl.asOWLObjectProperty(OWLObjectInverseOfImpl.java:131)
	at uk.ac.manchester.syntactic_locality.SyntacticLocalityChecker$PositiveOWLClassExpressionVisitor.visit(SyntacticLocalityChecker.java:1493)
	at uk.ac.manchester.cs.owl.owlapi.OWLObjectAllValuesFromImpl.accept(OWLObjectAllValuesFromImpl.java:82)
	at uk.ac.manchester.syntactic_locality.SyntacticLocalityChecker.isPositiveOWLClassExpression(SyntacticLocalityChecker.java:158)
	at uk.ac.manchester.syntactic_locality.SyntacticLocalityChecker.visit(SyntacticLocalityChecker.java:276)
	at uk.ac.manchester.cs.owl.owlapi.OWLSubClassOfAxiomImpl.accept(OWLSubClassOfAxiomImpl.java:112)
	at uk.ac.manchester.syntactic_locality.SyntacticLocalityChecker.isLocalAxiom(SyntacticLocalityChecker.java:126)
	at uk.ac.manchester.syntactic_locality.ModuleExtractor.extractModuleAxiomsForGroupSignature(ModuleExtractor.java:524)
	at uk.ac.manchester.syntactic_locality.ModuleExtractor.getLocalityModuleForSignatureGroup(ModuleExtractor.java:369)
	at uk.ac.manchester.syntactic_locality.ModuleExtractor.getLocalityModuleForSignatureGroup(ModuleExtractor.java:353)
	at uk.ac.ox.krr.logmap2.LogMap2Core.createOutput4Overlapping(LogMap2Core.java:1733)
	at uk.ac.ox.krr.logmap2.LogMap2Core.<init>(LogMap2Core.java:516)
	at uk.ac.ox.krr.logmap2.LogMap2Core.<init>(LogMap2Core.java:197)
	at uk.ac.ox.krr.logmap2.LogMap2_Matcher.<init>(LogMap2_Matcher.java:70)
	at uk.ac.ox.krr.logmap2.LogMap2_Matcher.<init>(LogMap2_Matcher.java:48)
	at uk.ac.ox.krr.logmap2.LogMap2_CommandLine.main(LogMap2_CommandLine.java:106)
```

Depending on the parameters.txt configuration, you may get either the exception itself or an `Error accessing object.` string.
## Proposed Fix:

The initial 'kludge patch' (hack) was to apply a guard: `if (!dualRoles && (desc.getProperty().isAnonymous() || !foreignSignature.contains(...))`

However, this would treat all inverse expressions as positive unconditionally. In turn this would risk dropping axioms from modules that should be retained (and could lead to incomplete module extraction -> missing entailments over the target signature).

As previously written, the fix would collapses both cases: (1) desc.getProperty().isAnonymous(), and (2) !foreignSignature.contains(...), into: any anonymous expression is unconditionally treated as role-external; which is equivalent to asserting $Sig(inv(p)) \cap \Sigma = \emptyset$ _(regardless of p)_, which is false whenever $p \in \Sigma$ (where $\Sigma$ is the foreign vocabulary/signature). Therefore, we might write an explicit patch (provided here for documentation purposes), as:

```java
if (isPositiveOWLClassExpression(desc.getFiller())) {
	isPositiveDescription = true;
} else if (!dualRoles) {
	OWLObjectPropertyExpression propExpr = desc.getProperty();     // inv(p) || p
	OWLObjectProperty namedProp = propExpr.isAnonymous()           // if inv(p)
		? propExpr.getNamedProperty()                              // unwrap : inv(p) -> p
		: propExpr.asOWLObjectProperty();                          // else p
	isPositiveDescription = !foreignSignature.contains(namedProp); // !inForeignSig p : p <- inv(p) || p
} else {
	isPositiveDescription = false;
}
```

However, this quite verbose and, as it turns out, quite unnecessary. Upon closer inspection:

`.getNamedProperty() // Returns P if this expression is either P or inv(P).`

See: 
https://owlcs.github.io/owlapi/apidocs_5/org/semanticweb/owlapi/model/OWLObjectProperty.html#getNamedProperty--

As such, we can conviently write:

```java
public void visit(OWLObjectAllValuesFrom desc) {
	if (isPositiveOWLClassExpression(desc.getFiller()))
		isPositiveDescription = true;
	else if (!dualRoles && !foreignSignature.contains(desc.getProperty().getNamedProperty())) // <-- JD. accounts for inv(p) || p
		isPositiveDescription = true; // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	else
		isPositiveDescription = false;
}
```

This PR proposes that we replace all `asOWLObjectProperty` method calls with `getNamedProperty` within [SyntacticLocalityChecker.java](https://github.com/ernestojimenezruiz/logmap-matcher/blob/master/src/main/java/uk/ac/manchester/syntactic_locality/SyntacticLocalityChecker.java).

Reasoning: Its justified by the OWL API specification.

Alternatively, _(in an abundance of caution))_ we can apply the fix to [the single line @ 1497](https://github.com/ernestojimenezruiz/logmap-matcher/blob/master/src/main/java/uk/ac/manchester/syntactic_locality/SyntacticLocalityChecker.java#L1493).

Note: this implementation has been compiled and tested agaisnt the set of original ontologies that caused the exception to raise. The exception no longer raises.
### References:
1. https://owlcs.github.io/owlapi/apidocs_4/org/semanticweb/owlapi/model/OWLObjectPropertyExpression.html#asOWLObjectProperty--
2. https://owlcs.github.io/owlapi/apidocs_5/org/semanticweb/owlapi/model/OWLObjectProperty.html#getNamedProperty--